### PR TITLE
Fixing module path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.2-0",
   "description": "Verifiable Credentials Status List Context.",
   "main": "js/index.js",
-  "module": "./dist/context.esm.js",
+  "module": "./dist/context.js",
   "files": [
     "contexts",
     "dist/context.js",


### PR DESCRIPTION
The context file has not the .esm included. Therefore the building can fail if the module and not the main file is used,